### PR TITLE
Allow user to pick Service Accounts and Group Managed Service Accounts

### DIFF
--- a/Tulpep.ActiveDirectoryObjectPicker/DirectoryObjectPickerDialog.cs
+++ b/Tulpep.ActiveDirectoryObjectPicker/DirectoryObjectPickerDialog.cs
@@ -320,6 +320,10 @@ namespace Tulpep.ActiveDirectoryObjectPicker
             {
                 defaultFilter |= DSOP_SCOPE_INIT_INFO_FLAGS.DSOP_SCOPE_FLAG_DEFAULT_FILTER_CONTACTS;
             }
+            if ((defaultTypes & ObjectTypes.ServiceAccounts) == ObjectTypes.ServiceAccounts)
+            {
+                defaultFilter |= DSOP_SCOPE_INIT_INFO_FLAGS.DSOP_SCOPE_FLAG_DEFAULT_FILTER_SERVICE_ACCOUNTS;
+            }
             return defaultFilter;
         }
 
@@ -403,7 +407,11 @@ namespace Tulpep.ActiveDirectoryObjectPicker
             {
                 uplevelFilter |= DSOP_FILTER_FLAGS_FLAGS.DSOP_FILTER_WELL_KNOWN_PRINCIPALS;
             }
-            if( showAdvancedView ) {
+            if ((allowedTypes & ObjectTypes.ServiceAccounts) == ObjectTypes.ServiceAccounts)
+            {
+                uplevelFilter |= DSOP_FILTER_FLAGS_FLAGS.DSOP_FILTER_SERVICE_ACCOUNTS;
+            }
+            if ( showAdvancedView ) {
                 uplevelFilter |= DSOP_FILTER_FLAGS_FLAGS.DSOP_FILTER_INCLUDE_ADVANCED_VIEW;
             }
             return uplevelFilter;

--- a/Tulpep.ActiveDirectoryObjectPicker/ObjectTypes.cs
+++ b/Tulpep.ActiveDirectoryObjectPicker/ObjectTypes.cs
@@ -65,11 +65,16 @@ namespace Tulpep.ActiveDirectoryObjectPicker
         /// In a down-level scope, this includes all well-known SIDs.
         /// </para>
         /// </remarks>
-        WellKnownPrincipals = 0x0020, 
+        WellKnownPrincipals = 0x0020,
+
+        /// <summary>
+        /// Includes all service accounts and group managed service accounts. 
+        /// </summary>
+        ServiceAccounts = 0x0040,
 
         /// <summary>
         /// All object types.
         /// </summary>
-        All = 0x003F
+        All = 0x007F
     }
 }


### PR DESCRIPTION
Yes I've noticed the comment regarding the fact that these enums were added in windows sdk 7. Yet I still  don't understand why not use them?

Thanks,

Jonathan