### PR TITLE
Also support a .NET 4.5 build and lib in NuGet package

### DIFF
--- a/Nuget/specs.nuspec
+++ b/Nuget/specs.nuspec
@@ -1,34 +1,37 @@
 ﻿<?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
-  <metadata>
-      <id>Tulpep.ActiveDirectoryObjectPicker</id>
-      <version>$version$</version>
-      <title>Active Directory Object Picker</title>
-      <authors>Armand du Plessis; Tulpep</authors>
-      <licenseUrl>https://raw.githubusercontent.com/Tulpep/Active-Directory-Dialogs/master/LICENSE</licenseUrl>
-      <projectUrl>https://github.com/Tulpep/Active-Directory-Dialogs</projectUrl>
-      <requireLicenseAcceptance>false</requireLicenseAcceptance>
-      <description>Active Directory Object Picker.</description>
-      <summary>Active Directory Object Picker.</summary>
-      <releaseNotes />
-  	  <tags>WPF Active Directory Dialog WinForms Windows Forms Picker</tags>
-      <frameworkAssemblies>
-          <frameworkAssembly assemblyName="System.Windows.Forms" />
-      </frameworkAssemblies>
-    </metadata>
-    <files>
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v2.0\ActiveDirectoryObjectPicker.dll" target="lib\net20" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v2.0\ActiveDirectoryObjectPicker.pdb" target="lib\net20" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v2.0\ActiveDirectoryObjectPicker.xml" target="lib\net20" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v3.5\ActiveDirectoryObjectPicker.dll" target="lib\net35" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v3.5\ActiveDirectoryObjectPicker.pdb" target="lib\net35" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v3.5\ActiveDirectoryObjectPicker.xml" target="lib\net35" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.0\ActiveDirectoryObjectPicker.dll" target="lib\net40" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.0\ActiveDirectoryObjectPicker.pdb" target="lib\net40" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.0\ActiveDirectoryObjectPicker.xml" target="lib\net40" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.5.2\ActiveDirectoryObjectPicker.dll" target="lib\net452" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.5.2\ActiveDirectoryObjectPicker.pdb" target="lib\net452" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.5.2\ActiveDirectoryObjectPicker.xml" target="lib\net452" />
-      <file src="..\Tulpep.ActiveDirectoryObjectPicker\*.cs" target="src" />
+	<metadata>
+			<id>Tulpep.ActiveDirectoryObjectPicker</id>
+			<version>$version$</version>
+			<title>Active Directory Object Picker</title>
+			<authors>Armand du Plessis; Tulpep</authors>
+			<licenseUrl>https://raw.githubusercontent.com/Tulpep/Active-Directory-Dialogs/master/LICENSE</licenseUrl>
+			<projectUrl>https://github.com/Tulpep/Active-Directory-Dialogs</projectUrl>
+			<requireLicenseAcceptance>false</requireLicenseAcceptance>
+			<description>Active Directory Object Picker.</description>
+			<summary>Active Directory Object Picker.</summary>
+			<releaseNotes />
+			<tags>WPF Active Directory Dialog WinForms Windows Forms Picker</tags>
+			<frameworkAssemblies>
+					<frameworkAssembly assemblyName="System.Windows.Forms" />
+			</frameworkAssemblies>
+		</metadata>
+		<files>
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v2.0\ActiveDirectoryObjectPicker.dll" target="lib\net20" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v2.0\ActiveDirectoryObjectPicker.pdb" target="lib\net20" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v2.0\ActiveDirectoryObjectPicker.xml" target="lib\net20" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v3.5\ActiveDirectoryObjectPicker.dll" target="lib\net35" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v3.5\ActiveDirectoryObjectPicker.pdb" target="lib\net35" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v3.5\ActiveDirectoryObjectPicker.xml" target="lib\net35" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.0\ActiveDirectoryObjectPicker.dll" target="lib\net40" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.0\ActiveDirectoryObjectPicker.pdb" target="lib\net40" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.0\ActiveDirectoryObjectPicker.xml" target="lib\net40" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.5\ActiveDirectoryObjectPicker.dll" target="lib\net45" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.5\ActiveDirectoryObjectPicker.pdb" target="lib\net45" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.5\ActiveDirectoryObjectPicker.xml" target="lib\net45" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.5.2\ActiveDirectoryObjectPicker.dll" target="lib\net452" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.5.2\ActiveDirectoryObjectPicker.pdb" target="lib\net452" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\bin\Release\v4.5.2\ActiveDirectoryObjectPicker.xml" target="lib\net452" />
+			<file src="..\Tulpep.ActiveDirectoryObjectPicker\*.cs" target="src" />
 	</files>
 </package>

--- a/Tulpep.ActiveDirectoryObjectPicker/Tulpep.ActiveDirectoryObjectPicker.csproj
+++ b/Tulpep.ActiveDirectoryObjectPicker/Tulpep.ActiveDirectoryObjectPicker.csproj
@@ -191,6 +191,7 @@
   <Target Name="AfterBuild">
     <MSBuild Condition=" $(TargetFrameworkVersion.Replace(&quot;v&quot;,&quot;&quot;)) == 2.0 " Projects="$(MSBuildProjectFile)" Properties="TargetFrameworkVersion=v3.5" RunEachTargetSeparately="true" />
     <MSBuild Condition=" $(TargetFrameworkVersion.Replace(&quot;v&quot;,&quot;&quot;)) == 3.5 " Projects="$(MSBuildProjectFile)" Properties="TargetFrameworkVersion=v4.0" RunEachTargetSeparately="true" />
-    <MSBuild Condition=" $(TargetFrameworkVersion.Replace(&quot;v&quot;,&quot;&quot;)) == 4.0 " Projects="$(MSBuildProjectFile)" Properties="TargetFrameworkVersion=v4.5.2" RunEachTargetSeparately="true" />
+    <MSBuild Condition=" $(TargetFrameworkVersion.Replace(&quot;v&quot;,&quot;&quot;)) == 4.0 " Projects="$(MSBuildProjectFile)" Properties="TargetFrameworkVersion=v4.5" RunEachTargetSeparately="true" />
+    <MSBuild Condition=" $(TargetFrameworkVersion.Replace(&quot;v&quot;,&quot;&quot;)) == 4.5 " Projects="$(MSBuildProjectFile)" Properties="TargetFrameworkVersion=v4.5.2" RunEachTargetSeparately="true" />
   </Target>
 </Project>


### PR DESCRIPTION
When I did the last PR for this project I set it up to build for .NET 2, 3.5, 4 and 4.5.2. I've had requests in my dependent packages to also support 4.5. These simple changes merely add that build. There should be no adverse affects. Once merged, will you push an update to the NuGet package? It would be of immense help. Thank you.